### PR TITLE
Fix menu item titles

### DIFF
--- a/src/main/res/menu/activity_ticket_view.xml
+++ b/src/main/res/menu/activity_ticket_view.xml
@@ -12,7 +12,7 @@
     <item
         android:id="@+id/menu_share"
         yourapp:showAsAction="ifRoom"
-        android:title="@string/menu_delete"
+        android:title="@string/menu_share"
         android:icon="@android:drawable/ic_menu_share" />
 
 </menu>

--- a/src/main/res/menu/map_item.xml
+++ b/src/main/res/menu/map_item.xml
@@ -3,6 +3,6 @@
     <item
         android:id="@+id/menu_map"
         yourapp:showAsAction="ifRoom"
-        android:title="@string/menu_delete"
+        android:title="@string/menu_map"
         android:icon="@android:drawable/ic_menu_mapmode" />
 </menu>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -4,7 +4,9 @@
     <string name="app_name">PassAndroid</string>
     <string name="menu_settings">Settings</string>
     <string name="logo">logo</string>
+    <string name="menu_map">show on map</string>
     <string name="menu_delete">delete</string>
+    <string name="menu_share">share</string>
     <string name="menu_refresh">refresh</string>
     <string name="barcode">barcode</string>
 


### PR DESCRIPTION
All menu items in the ticket view activity had the title "delete".

For consistency reasons the new menu labels also start with a lower case letter. However, I believe it'd look better if you changed the strings to start with an upper case letter.
