### PR TITLE
Update ApplePassbookQuirkCorrector.java

### DIFF
--- a/src/main/java/org/ligi/passandroid/model/ApplePassbookQuirkCorrector.java
+++ b/src/main/java/org/ligi/passandroid/model/ApplePassbookQuirkCorrector.java
@@ -15,8 +15,24 @@ public class ApplePassbookQuirkCorrector {
         careForVirginAustralia(pass);
         careForCathayPacific(pass);
         careForSWISS(pass);
+        careForRenfe(pass);
     }
-
+    
+    private static void careForRenfe(PassImpl pass) {
+    	if (!pass.getOrganisation().isPresent() || !pass.getOrganisation().get().equals("RENFE OPERADORA")) {
+    		return;
+    	}
+    	Tracker.get().trackEvent("quirk_fix", "description_replace", "RENFE OPERADORA", 0L);
+    	
+    	final Optional<PassField> optionalDepart = pass.getPrimaryFields().getPassFieldForKey("boardingTime");
+    	final Optional<PassField> optionalArrive = pass.getPrimaryFields().getPassFieldForKey("destino");
+    	
+    	if (optionalDepart.isPresent() && optionalArrive.isPresent()) {
+    		Tracker.get().trackEvent("quirk_fix", "description_replace", "RENFE OPERADORA", 1L);
+    		pass.setDescription(optionalDepart.get().label + " -> " + optionalArrive.get().label);
+    	}
+    }
+    
     private static void careForSWISS(PassImpl pass) {
         if (!pass.getOrganisation().isPresent() || !pass.getOrganisation().get().equals("SWISS")) {
             return;


### PR DESCRIPTION
This should format the main title to be something like
`VALENC.JSO -> MADRID-P.A`
Which indicates the city/train terminal for source and destination

given the Json:

```
{
    "formatVersion":1,
    ...
    "organizationName":"RENFE OPERADORA",
    "description":"Billete de tren",
    ...
    "boardingPass":{
        "headerFields":[{"key":"destinofecha","label":"Viaje a: MADRID-P.A","value":"20/06/2014"}],
        "primaryFields":[
            {"key":"boardingTime","label":"VALENC.JSO","value":"17:10","changeMessage":"La hora de salida ha cambiado a %@"},
            {"key":"destino","label":"MADRID-P.A","value":"18:48"}],
    ...
```

Please note this code has not been tested.
