### PR TITLE
Improve default topic categorisation of passes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ gen
 project.properties
 gradle.properties
 local.properties
+*iml
+/build.gradle

--- a/android/src/main/java/org/ligi/passandroid/ui/SearchSuccessCallback.kt
+++ b/android/src/main/java/org/ligi/passandroid/ui/SearchSuccessCallback.kt
@@ -53,7 +53,7 @@ internal class SearchSuccessCallback(private val context: Context, private val p
 
     private fun getInitialTopic(pass: Pass): String {
         val passDate = getDateOfPassForComparison(pass)
-        if (passDate!!.isBefore(ZonedDateTime.now())) {
+        if (passDate != null && passDate.isBefore(ZonedDateTime.now())) {
             return context.getString(R.string.topic_archive)
         }
         return context.getString(R.string.topic_new)


### PR DESCRIPTION
Sorry, I screwed up the commit history a bit when trying to rebase everything as a single commit. So I have recreated the changes and opened a new PR.

Fixes #75

Previously the initial topic for a pass was simply "new".

After this change, if the pass was either in the pass (calendar timespan) or has expired (valid timespan) then it will have an initial topic of "archive".