### PR TITLE
Only show navigation tabs for at least 2 passes. Closes #189

### DIFF
--- a/android/src/main/java/org/ligi/passandroid/ui/PassListActivity.kt
+++ b/android/src/main/java/org/ligi/passandroid/ui/PassListActivity.kt
@@ -273,7 +273,7 @@ class PassListActivity : PassAndroidActivity() {
 
         val empty = passStore.classifier.topicByIdMap.isEmpty()
         emptyView.visibility = if (empty) View.VISIBLE else View.GONE
-        tab_layout.visibility = if (empty) View.GONE else View.VISIBLE
+        tab_layout.visibility = if (passStore.classifier.getTopics().size < 2) View.GONE else View.VISIBLE
     }
 
     private fun setupWithViewPagerIfNeeded() {

--- a/android/src/main/java/org/ligi/passandroid/ui/PassListActivity.kt
+++ b/android/src/main/java/org/ligi/passandroid/ui/PassListActivity.kt
@@ -273,7 +273,8 @@ class PassListActivity : PassAndroidActivity() {
 
         val empty = passStore.classifier.topicByIdMap.isEmpty()
         emptyView.visibility = if (empty) View.VISIBLE else View.GONE
-        tab_layout.visibility = if (passStore.classifier.getTopics().size < 2) View.GONE else View.VISIBLE
+        val onlyDefaultTopicExists = passStore.classifier.getTopics().all { it == getString(R.string.topic_new) }
+        tab_layout.visibility = if (onlyDefaultTopicExists) View.GONE else View.VISIBLE
     }
 
     private fun setupWithViewPagerIfNeeded() {


### PR DESCRIPTION
Implemented this as default behavior. What do you think, should it be configurable in settings?

Is advanced functionality required?
- Show view pager for trash
- Show view pager for non-default topics even when it's not the only one?