### PR TITLE
Regard barcode message encoding if provided in .pkpass

### DIFF
--- a/android/src/main/java/org/ligi/passandroid/functions/Barcode.kt
+++ b/android/src/main/java/org/ligi/passandroid/functions/Barcode.kt
@@ -3,13 +3,15 @@ package org.ligi.passandroid.functions
 import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
+import com.google.zxing.EncodeHintType
 import com.google.zxing.MultiFormatWriter
+import com.google.zxing.common.CharacterSetECI
 import org.ligi.passandroid.model.pass.PassBarCodeFormat
 import org.ligi.tracedroid.logging.Log
 
 
-fun generateBitmapDrawable(resources: Resources, data: String, type: PassBarCodeFormat): BitmapDrawable? {
-    val bitmap = generateBarCodeBitmap(data, type) ?: return null
+fun generateBitmapDrawable(resources: Resources, data: String, type: PassBarCodeFormat, encoding: String?): BitmapDrawable? {
+    val bitmap = generateBarCodeBitmap(data, type, encoding) ?: return null
 
     return BitmapDrawable(resources, bitmap).apply {
         isFilterBitmap = false
@@ -17,14 +19,15 @@ fun generateBitmapDrawable(resources: Resources, data: String, type: PassBarCode
     }
 }
 
-fun generateBarCodeBitmap(data: String, type: PassBarCodeFormat): Bitmap? {
+fun generateBarCodeBitmap(data: String, type: PassBarCodeFormat, encoding: String?): Bitmap? {
 
     if (data.isEmpty()) {
         return null
     }
 
     try {
-        val matrix = getBitMatrix(data, type)
+        val hints = if (null != CharacterSetECI.getCharacterSetECIByName(encoding)) mapOf(Pair(EncodeHintType.CHARACTER_SET, "UTF-8")) else null
+        val matrix = getBitMatrix(data, type, hints)
         val is1D = matrix.height == 1
 
         // generate an image from the byte matrix
@@ -58,6 +61,6 @@ fun generateBarCodeBitmap(data: String, type: PassBarCodeFormat): Bitmap? {
 
 }
 
-fun getBitMatrix(data: String, type: PassBarCodeFormat)
-        = MultiFormatWriter().encode(data, type.zxingBarCodeFormat(), 0, 0)!!
+fun getBitMatrix(data: String, type: PassBarCodeFormat, hints: Map<EncodeHintType, Any?>? = null)
+        = MultiFormatWriter().encode(data, type.zxingBarCodeFormat(), 0, 0, hints)!!
 

--- a/android/src/main/java/org/ligi/passandroid/model/pass/BarCode.kt
+++ b/android/src/main/java/org/ligi/passandroid/model/pass/BarCode.kt
@@ -12,6 +12,7 @@ import java.util.*
 class BarCode(val format: PassBarCodeFormat?, val message: String? = UUID.randomUUID().toString().toUpperCase()) {
 
     var alternativeText: String? = null
+    var encoding: String? = null
 
     fun getBitmap(resources: Resources): BitmapDrawable? {
         val tracker: Tracker = App.kodein.instance()
@@ -24,10 +25,10 @@ class BarCode(val format: PassBarCodeFormat?, val message: String? = UUID.random
         if (format == null) {
             Log.w("Barcode format is null - fallback to QR")
             tracker.trackException("Barcode format is null - fallback to QR", false)
-            return generateBitmapDrawable(resources, message, PassBarCodeFormat.QR_CODE)
+            return generateBitmapDrawable(resources, message, PassBarCodeFormat.QR_CODE, encoding)
         }
 
-        return generateBitmapDrawable(resources, message, format)
+        return generateBitmapDrawable(resources, message, format, encoding)
 
     }
 

--- a/android/src/main/java/org/ligi/passandroid/reader/AppleStylePassReader.kt
+++ b/android/src/main/java/org/ligi/passandroid/reader/AppleStylePassReader.kt
@@ -91,9 +91,8 @@ object AppleStylePassReader {
                 val barCode = BarCode(barcodeFormat, barcode_json.getString("message"))
                 pass.barCode = barCode
 
-                if (barcode_json.has("altText")) {
-                    pass.barCode!!.alternativeText = barcode_json.getString("altText")
-                }
+                pass.barCode!!.alternativeText = barcode_json.optString("altText", null)
+                pass.barCode!!.encoding = barcode_json.optString("messageEncoding", null)
             }
             // TODO should check a bit more with barcode here - this can be dangerous
         } catch (ignored: Exception) {


### PR DESCRIPTION
This PR adresse #200 

Enoding from pass.json is taken into account (QR code looks differently now), but unfortunately not the same as the code from the email that worked. So I'm not sure, if the pass would work now, and can't test in the near future as I won't need any parcel stamps.