### PR TITLE
Temporarily opt out of Android 10 scoped storage

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -26,7 +26,8 @@
             android:icon="@drawable/ic_launcher"
             android:label="@string/app_name"
             android:resizeableActivity="true"
-            android:theme="@style/AppTheme">
+            android:theme="@style/AppTheme"
+            android:requestLegacyExternalStorage="true">
 
         <receiver
                 android:name=".InstallListener"


### PR DESCRIPTION
Using the app in Android 10 all file pickers fail to open the selected file because although the storage permission is given Android 10 scopes storage by default. A quick resolution would be to [opt out of scoped storage](https://developer.android.com/training/data-storage/use-cases#opt-out-in-production-app), at least for use on Android 10.

Backtrace of the error experienced that this PR will hopefully fix:
```
07-16 00:05:52.506 22625 22625 W System.err: java.io.FileNotFoundException: /storage/emulated/0/Download/flag_yellow_low.jpg: open failed: EACCES (Permission denied)
07-16 00:05:52.506 22625 22625 W System.err: 	at libcore.io.IoBridge.open(IoBridge.java:496)
07-16 00:05:52.506 22625 22625 W System.err: 	at java.io.FileInputStream.<init>(FileInputStream.java:159)
07-16 00:05:52.506 22625 22625 W System.err: 	at kotlin.io.FilesKt__UtilsKt.c(SourceFile:10)
07-16 00:05:52.506 22625 22625 W System.err: 	at kotlin.io.FilesKt__UtilsKt.d(SourceFile:1)
07-16 00:05:52.507 22625 22625 W System.err: 	at kotlin.io.FilesKt.d(Unknown Source:0)
07-16 00:05:52.507 22625 22625 W System.err: 	at org.ligi.passandroid.ui.edit.ImageEditHelper.a(SourceFile:6)
07-16 00:05:52.507 22625 22625 W System.err: 	at org.ligi.passandroid.ui.edit.ImageEditHelper.b(SourceFile:2)
07-16 00:05:52.507 22625 22625 W System.err: 	at org.ligi.passandroid.ui.PassEditActivity.onActivityResult(SourceFile:2)
07-16 00:05:52.507 22625 22625 W System.err: 	at android.app.Activity.dispatchActivityResult(Activity.java:8151)
07-16 00:05:52.507 22625 22625 W System.err: 	at android.app.ActivityThread.deliverResults(ActivityThread.java:4839)
07-16 00:05:52.507 22625 22625 W System.err: 	at android.app.ActivityThread.handleSendResult(ActivityThread.java:4887)
07-16 00:05:52.507 22625 22625 W System.err: 	at android.app.servertransaction.ActivityResultItem.execute(ActivityResultItem.java:51)
07-16 00:05:52.507 22625 22625 W System.err: 	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:139)
07-16 00:05:52.507 22625 22625 W System.err: 	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
07-16 00:05:52.507 22625 22625 W System.err: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2017)
07-16 00:05:52.507 22625 22625 W System.err: 	at android.os.Handler.dispatchMessage(Handler.java:107)
07-16 00:05:52.507 22625 22625 W System.err: 	at android.os.Looper.loop(Looper.java:214)
07-16 00:05:52.507 22625 22625 W System.err: 	at android.app.ActivityThread.main(ActivityThread.java:7397)
07-16 00:05:52.508 22625 22625 W System.err: 	at java.lang.reflect.Method.invoke(Native Method)
07-16 00:05:52.508 22625 22625 W System.err: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
07-16 00:05:52.508 22625 22625 W System.err: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:935)
07-16 00:05:52.508 22625 22625 W System.err: Caused by: android.system.ErrnoException: open failed: EACCES (Permission denied)
07-16 00:05:52.508 22625 22625 W System.err: 	at libcore.io.Linux.open(Native Method)
07-16 00:05:52.508 22625 22625 W System.err: 	at libcore.io.ForwardingOs.open(ForwardingOs.java:167)
07-16 00:05:52.508 22625 22625 W System.err: 	at libcore.io.BlockGuardOs.open(BlockGuardOs.java:252)
07-16 00:05:52.508 22625 22625 W System.err: 	at libcore.io.ForwardingOs.open(ForwardingOs.java:167)
07-16 00:05:52.509 22625 22625 W System.err: 	at android.app.ActivityThread$AndroidOs.open(ActivityThread.java:7296)
07-16 00:05:52.509 22625 22625 W System.err: 	at libcore.io.IoBridge.open(IoBridge.java:482)
07-16 00:05:52.509 22625 22625 W System.err: 	... 20 more
```