### PR TITLE
Round the initial time of a pass to the next half hour

### DIFF
--- a/android/src/main/java/org/ligi/passandroid/ui/pass_view_holder/EditViewHolder.kt
+++ b/android/src/main/java/org/ligi/passandroid/ui/pass_view_holder/EditViewHolder.kt
@@ -16,6 +16,7 @@ import org.ligi.passandroid.model.pass.Pass
 import org.ligi.passandroid.model.pass.PassImpl
 import org.ligi.passandroid.ui.Visibility
 import org.threeten.bp.ZonedDateTime
+import org.threeten.bp.temporal.ChronoUnit
 
 class EditViewHolder(view: CardView) : VerbosePassViewHolder(view), TimePickerDialog.OnTimeSetListener, DatePickerDialog.OnDateSetListener {
 
@@ -33,7 +34,8 @@ class EditViewHolder(view: CardView) : VerbosePassViewHolder(view), TimePickerDi
         time = if (calendarTimespan?.from != null) {
             calendarTimespan.from
         } else {
-            ZonedDateTime.now()
+            val roundedTime = ZonedDateTime.now().truncatedTo(ChronoUnit.MINUTES)
+            roundedTime.plusMinutes(30L - (roundedTime.minute % 30))
         }
     }
 


### PR DESCRIPTION
I create a lot of passes manually and thus am a bit bugged by always setting the time manually. I think a better default than the current time would be to round up to the next half hour. I see also popular calendar apps doing the same.

With the change this is how the time would be rounded:

18:22:00 -> 18:30
18:30:00 -> 18:30
18:30:07 -> 18:30
18:32:00 -> 19:00

Additionally I truncated to minutes so that seconds and nanos are always 0. I don't think this offers a direct benefit, but makes time handling more clean.