### PR TITLE
Support scanning codes with Binary Eye

### DIFF
--- a/android/src/main/java/org/ligi/passandroid/ui/edit/BarCodeIntentIntegrator.java
+++ b/android/src/main/java/org/ligi/passandroid/ui/edit/BarCodeIntentIntegrator.java
@@ -103,6 +103,7 @@ public class BarCodeIntentIntegrator {
 
     private static final String BS_PACKAGE = "com.google.zxing.client.android";
     private static final String BSPLUS_PACKAGE = "com.srowen.bs.android";
+    private static final String BINARYEYE_PACKAGE = "de.markusfisch.android.binaryeye";
 
     // supported barcode formats
     public static final Collection<String> PRODUCT_CODE_TYPES = list("UPC_A", "UPC_E", "EAN_8", "EAN_13", "RSS_14");
@@ -116,6 +117,7 @@ public class BarCodeIntentIntegrator {
 
     public static final List<String> TARGET_BARCODE_SCANNER_ONLY = Collections.singletonList(BS_PACKAGE);
     public static final List<String> TARGET_ALL_KNOWN = list(
+            BINARYEYE_PACKAGE,          // Binary Eye
             BSPLUS_PACKAGE,             // Barcode Scanner+
             BSPLUS_PACKAGE + ".simple", // Barcode Scanner+ Simple
             BS_PACKAGE                  // Barcode Scanner


### PR DESCRIPTION
Binary Eye is a modern ZXing-based code scanner app, which supports the Barcode Scanner intent API, and so it’s a drop-in replacement when apps don’t hardcode the Barcode Scanner’s app id.

