### PR TITLE
Pkpass renderer

### DIFF
--- a/android/src/main/java/org/ligi/passandroid/functions/CategoryHelper.kt
+++ b/android/src/main/java/org/ligi/passandroid/functions/CategoryHelper.kt
@@ -9,6 +9,7 @@ import org.ligi.passandroid.model.pass.PassType
 @StringRes
 fun getHumanCategoryString(fromPass: PassType) = when (fromPass) {
     PassType.BOARDING -> R.string.boarding_pass
+    PassType.PKBOARDING -> R.string.boarding_pass
     PassType.EVENT -> R.string.category_event
     PassType.COUPON -> R.string.category_coupon
     PassType.LOYALTY -> R.string.category_storecard
@@ -20,6 +21,7 @@ fun getHumanCategoryString(fromPass: PassType) = when (fromPass) {
 @ColorInt
 fun getCategoryDefaultBG(category: PassType) = when (category) {
     PassType.BOARDING -> 0xFF3d73e9
+    PassType.PKBOARDING -> 0xFF3d73e9
     PassType.EVENT -> 0xFF9f3dd0
     PassType.COUPON -> 0xFF9ccb05
     PassType.LOYALTY -> 0xFFf29b21
@@ -31,6 +33,7 @@ fun getCategoryDefaultBG(category: PassType) = when (category) {
 @DrawableRes
 fun getCategoryTopImageRes(type: PassType) = when (type) {
     PassType.BOARDING -> R.drawable.cat_bp
+    PassType.PKBOARDING -> R.drawable.cat_bp
     PassType.EVENT -> R.drawable.cat_et
     PassType.COUPON -> R.drawable.cat_cp
     PassType.LOYALTY -> R.drawable.cat_sc

--- a/android/src/main/java/org/ligi/passandroid/model/PassDefinitions.kt
+++ b/android/src/main/java/org/ligi/passandroid/model/PassDefinitions.kt
@@ -6,7 +6,7 @@ object PassDefinitions {
 
     val TYPE_TO_NAME = mapOf(COUPON to "coupon",
             EVENT to "eventTicket",
-            BOARDING to "boardingPass",
+            PKBOARDING to "boardingPass",
             GENERIC to "generic",
             LOYALTY to "storeCard")
 

--- a/android/src/main/java/org/ligi/passandroid/model/pass/PassField.kt
+++ b/android/src/main/java/org/ligi/passandroid/model/pass/PassField.kt
@@ -5,7 +5,7 @@ import androidx.annotation.StringRes
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-class PassField(var key: String?, var label: String?, var value: String?, var hide: Boolean) {
+class PassField(var key: String?, var label: String?, var value: String?, var hide: Boolean, var hint:String? = null) {
 
     fun toHtmlSnippet(): String {
         val result = StringBuilder()
@@ -20,6 +20,6 @@ class PassField(var key: String?, var label: String?, var value: String?, var hi
     }
 
     companion object {
-        fun create(@StringRes label: Int, @StringRes value: Int, res: Resources, hide: Boolean = false) = PassField(null, res.getString(label), res.getString(value), hide)
+        fun create(@StringRes label: Int, @StringRes value: Int, res: Resources, hide: Boolean = false, hint: String? = null) = PassField(null, res.getString(label), res.getString(value), hide, hint)
     }
 }

--- a/android/src/main/java/org/ligi/passandroid/model/pass/PassType.kt
+++ b/android/src/main/java/org/ligi/passandroid/model/pass/PassType.kt
@@ -5,6 +5,7 @@ enum class PassType {
     EVENT,
     COUPON,
     BOARDING,
+    PKBOARDING,
     LOYALTY,
     VOUCHER
 }

--- a/android/src/main/java/org/ligi/passandroid/reader/AppleStylePassReader.kt
+++ b/android/src/main/java/org/ligi/passandroid/reader/AppleStylePassReader.kt
@@ -226,7 +226,8 @@ object AppleStylePassReader {
                     val field = PassField(key = getField(jsonObject, "key", translation),
                             label = getField(jsonObject, "label", translation),
                             value = getField(jsonObject, "value", translation),
-                            hide = hide)
+                            hide = hide,
+                            hint = fieldsName)
                     list.add(field)
 
                 } catch (e: JSONException) {

--- a/android/src/main/java/org/ligi/passandroid/ui/PassViewActivity.kt
+++ b/android/src/main/java/org/ligi/passandroid/ui/PassViewActivity.kt
@@ -18,6 +18,7 @@ import org.ligi.kaxt.disableRotation
 import org.ligi.passandroid.R
 import org.ligi.passandroid.model.PassStoreProjection
 import org.ligi.passandroid.model.pass.Pass
+import org.ligi.passandroid.model.pass.PassType
 
 class PassViewActivity : PassViewActivityBase() {
     private lateinit var pagerAdapter: CollectionPagerAdapter
@@ -65,8 +66,15 @@ class PassViewActivity : PassViewActivityBase() {
 
         override fun createFragment(i: Int): Fragment {
 
-            val fragment = PassViewFragment()
-            fragment.arguments = bundleOf(EXTRA_KEY_UUID to getPass(i).id)
+            val pass = getPass(i)
+
+            val fragment =
+                when (pass.type) {
+                    PassType.PKBOARDING -> PassViewPKFragment()
+                    else -> PassViewFragment()
+                }
+
+            fragment.arguments = bundleOf(EXTRA_KEY_UUID to pass.id)
             return fragment
         }
 

--- a/android/src/main/java/org/ligi/passandroid/ui/PassViewPKFragment.kt
+++ b/android/src/main/java/org/ligi/passandroid/ui/PassViewPKFragment.kt
@@ -1,0 +1,174 @@
+package org.ligi.passandroid.ui
+
+import android.content.Intent
+import android.os.Bundle
+import android.text.util.Linkify
+import android.view.LayoutInflater
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.util.TypedValue
+import android.widget.ImageView
+import android.widget.TextView
+import android.widget.RelativeLayout
+import androidx.core.text.parseAsHtml
+import androidx.core.text.util.LinkifyCompat
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import kotlinx.android.synthetic.main.activity_pass_view.*
+import kotlinx.android.synthetic.main.barcode.*
+import kotlinx.android.synthetic.main.pass_list_item.*
+import kotlinx.android.synthetic.main.pkpass_view_extra_data.*
+import org.koin.android.ext.android.inject
+import org.ligi.kaxt.startActivityFromClass
+import org.ligi.passandroid.R
+import org.ligi.passandroid.maps.PassbookMapsFacade
+import org.ligi.passandroid.model.PassBitmapDefinitions
+import org.ligi.passandroid.model.PassStore
+import org.ligi.passandroid.model.pass.Pass
+import org.ligi.passandroid.ui.pass_view_holder.VerbosePassViewHolder
+import android.util.Log
+
+class PassViewPKFragment : Fragment() {
+
+    private val passViewHelper by lazy { PassViewHelper(requireActivity()) }
+    internal val passStore: PassStore by inject()
+    lateinit var pass: Pass
+
+    private fun processImage(view: ImageView, name: String, pass: Pass) {
+        val bitmap = pass.getBitmap(passStore, name)
+        if (bitmap != null && bitmap.width > 300) {
+            view.setOnClickListener {
+                val intent = Intent(view.context, TouchImageActivity::class.java)
+                intent.putExtra("IMAGE", name)
+                startActivity(intent)
+            }
+        }
+        passViewHelper.setBitmapSafe(view, bitmap)
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        moreTextView.setOnClickListener {
+            if (back_fields.visibility == View.VISIBLE) {
+                back_fields.visibility = View.GONE
+                moreTextView.setText(R.string.more)
+            } else {
+                back_fields.visibility = View.VISIBLE
+                moreTextView.setText(R.string.less)
+            }
+        }
+
+        val fieldMap : Map<String, ViewGroup> = mapOf(
+            "primaryFields" to primary_field_container,
+            "auxiliaryFields" to auxiliary_field_container,
+            "headerFields" to header_field_container,
+            "secondaryFields" to secondary_field_container
+        )
+
+        val fieldCount = mutableMapOf<String, Int>()
+
+        fieldMap.forEach {
+            fieldCount[it.key] = 0
+        }
+
+        barcode_img.setOnClickListener {
+            activity?.startActivityFromClass(FullscreenBarcodeActivity::class.java)
+        }
+
+        BarcodeUIController(requireView(), pass.barCode, requireActivity(), passViewHelper)
+
+        processImage(logo_img_view, PassBitmapDefinitions.BITMAP_LOGO, pass)
+        processImage(footer_img_view, PassBitmapDefinitions.BITMAP_FOOTER, pass)
+        processImage(thumbnail_img_view, PassBitmapDefinitions.BITMAP_THUMBNAIL, pass)
+        processImage(strip_img_view, PassBitmapDefinitions.BITMAP_STRIP, pass)
+
+        if (map_container != null) {
+            if (!(pass.locations.isNotEmpty() && PassbookMapsFacade.init(activity as FragmentActivity))) {
+                @Suppress("PLUGIN_WARNING")
+                map_container.visibility = View.GONE
+            }
+        }
+
+        val backStrBuilder = StringBuilder()
+
+        fieldMap.forEach {
+            it.value.removeAllViews()
+        }
+
+        for (field in pass.fields) {
+            val hint = field.hint
+            if (field.hide) {
+                backStrBuilder.append(field.toHtmlSnippet())
+            } else if (hint != null) {
+                val v = requireActivity().layoutInflater.inflate(R.layout.vertical_field_item, header_field_container, false)
+                val key = v?.findViewById<TextView>(R.id.key)
+                key?.text = field.label
+                val value = v?.findViewById<TextView>(R.id.value)
+                value?.text = field.value
+                Log.i("PassAndroid", "creating header with tag = " + field.label + " value = " + field.value)
+
+                if (hint.equals("primaryFields")) {
+                    value?.textSize = 40f
+                    key?.textSize = 20f
+                    val params = RelativeLayout.LayoutParams(
+                        RelativeLayout.LayoutParams.WRAP_CONTENT,
+                        RelativeLayout.LayoutParams.WRAP_CONTENT
+                    )
+                    if (fieldCount[hint]!! == 0) {
+                        params.addRule(RelativeLayout.ALIGN_PARENT_LEFT)
+                        value?.setGravity(Gravity.LEFT)
+                        key?.setGravity(Gravity.LEFT)
+                        v?.setLayoutParams(params)
+                    } else {
+                        params.addRule(RelativeLayout.ALIGN_PARENT_RIGHT)
+                        value?.setGravity(Gravity.RIGHT)
+                        key?.setGravity(Gravity.RIGHT)
+                        v?.setLayoutParams(params)
+                    }
+                }
+                fieldMap[hint]!!.addView(v)
+                key?.let { LinkifyCompat.addLinks(it, Linkify.ALL) }
+                value?.let { LinkifyCompat.addLinks(it, Linkify.ALL) }
+                fieldCount[hint] = 1 + fieldCount[hint]!!
+                    
+            } 
+        }
+
+        if (backStrBuilder.isNotEmpty()) {
+            back_fields.text = "$backStrBuilder".parseAsHtml()
+            moreTextView.visibility = View.VISIBLE
+        } else {
+            moreTextView.visibility = View.GONE
+        }
+
+        LinkifyCompat.addLinks(back_fields, Linkify.ALL)
+
+        val passViewHolder = VerbosePassViewHolder(pass_card)
+        passViewHolder.apply(pass, passStore, requireActivity())
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
+                              savedInstanceState: Bundle?): View {
+
+        val rootView = inflater.inflate(R.layout.activity_pass_view_page, container, false)
+        arguments?.takeIf { it.containsKey(PassViewActivityBase.EXTRA_KEY_UUID) }?.apply {
+            val uuid = getString(PassViewActivityBase.EXTRA_KEY_UUID)
+            pass = if (uuid != null) {
+                passStore.getPassbookForId(uuid) ?: passStore.currentPass!!
+            } else {
+                passStore.currentPass!!
+            }
+        }
+
+        return rootView
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val passExtrasView = requireActivity().layoutInflater.inflate(R.layout.pkpass_view_extra_data, passExtrasContainer, false)
+        passExtrasContainer.addView(passExtrasView)
+    }
+}

--- a/android/src/main/res/layout/pkpass_view_extra_data.xml
+++ b/android/src/main/res/layout/pkpass_view_extra_data.xml
@@ -1,0 +1,110 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:orientation="vertical">
+  <!-- layout in https://developer.apple.com/library/archive/documentation/UserExperience/Conceptual/PassKit_PG/Creating.html -->
+
+    <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+		  xmlns:tools="http://schemas.android.com/tools"
+		  android:layout_width="match_parent"
+		  android:layout_height="wrap_content">
+        
+        <ImageView
+                android:id="@+id/logo_img_view"
+		android:scaleType="fitXY"
+		tools:src="@drawable/ic_launcher"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:adjustViewBounds="true"
+		android:layout_alignParentLeft="true"
+		tools:ignore="ContentDescription"
+		android:padding="8dp"/>
+
+        <LinearLayout
+                android:id="@+id/header_field_container"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:layout_alignParentRight="true"
+		android:orientation="horizontal"/>
+    </RelativeLayout>
+	
+
+
+    <ImageView
+            android:id="@+id/thumbnail_img_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            tools:ignore="ContentDescription"
+            android:adjustViewBounds="true"
+            android:paddingBottom="10dp"/>
+
+
+    <ImageView
+            android:id="@+id/strip_img_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:paddingBottom="10dp"
+            android:adjustViewBounds="true"
+            tools:ignore="ContentDescription"/>
+
+    <RelativeLayout
+            android:id="@+id/primary_field_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+	    android:paddingTop="10dp"
+	    android:paddingBottom="20dp"
+	    android:layout_gravity="center_horizontal"
+            android:orientation="horizontal"/>
+
+    <LinearLayout
+            android:id="@+id/auxiliary_field_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"/>
+
+    <LinearLayout
+            android:id="@+id/secondary_field_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"/>
+
+    <include layout="@layout/barcode"/>
+
+    <TextView
+            android:id="@+id/moreTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:fontFamily="sans-serif"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:padding="10dp"
+            android:text="@string/more"
+            android:textSize="21sp"/>
+
+    <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:animateLayoutChanges="true">
+
+        <TextView
+                android:id="@+id/back_fields"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif"
+                android:padding="24dp"
+                android:visibility="gone"/>
+    </LinearLayout>
+
+    <ImageView
+            android:id="@+id/footer_img_view"
+            android:scaleType="fitXY"
+            tools:src="@drawable/ic_launcher"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:adjustViewBounds="true"
+            tools:ignore="ContentDescription"
+            android:padding="8dp"/>
+</LinearLayout>

--- a/android/src/main/res/layout/vertical_field_item.xml
+++ b/android/src/main/res/layout/vertical_field_item.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_height="wrap_content"
+    android:layout_width="wrap_content"
+    android:layout_weight="1"
+    android:padding="8dp"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:fontFamily="sans-serif-light"
+        android:textSize="14sp"
+        tools:text="Key"
+        android:id="@+id/key" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+	android:gravity="center"
+        android:fontFamily="sans-serif"
+        android:textSize="18sp"
+        tools:text="Value"
+        android:id="@+id/value" />
+</LinearLayout>


### PR DESCRIPTION
Thanks for the great program.  I've been having trouble with a few gate agents who don't like the look of the espass linear boarding pass.  To fix this, I've added a renderer to PassAndroid that looks much more like the apple PKPASS view.  In order to do this, I've had to add hints to the espass main.json about which region in the PKPASS the field belongs.  This is a screenshot of what the new layout looks like:

![image](https://user-images.githubusercontent.com/281772/153304724-60e1c17c-b90f-4777-86fb-df804807db71.png)

Which looks much closer to the apple specification for a boarding pass:

https://developer.apple.com/library/archive/documentation/UserExperience/Conceptual/PassKit_PG/Creating.html#//apple_ref/doc/uid/TP40012195-CH4-SW8

