### PR TITLE
Fix temp file:java.ioIOExcepction: Stream Closed when loading a pkpas…

### DIFF
--- a/android/src/main/java/org/ligi/passandroid/functions/InputStreamProvider.kt
+++ b/android/src/main/java/org/ligi/passandroid/functions/InputStreamProvider.kt
@@ -65,8 +65,6 @@ private fun fromOKHttp(uri: Uri, tracker: Tracker): InputStreamWithSource? {
     return null
 }
 
-private fun fromContent(ctx: Context, uri: Uri) = ctx.contentResolver.openInputStream(uri)?.use {
-    InputStreamWithSource("$uri", it)
-}
+private fun fromContent(ctx: Context, uri: Uri) = InputStreamWithSource("$uri", ctx.contentResolver.openInputStream(uri)!!)
 
 private fun getDefaultInputStreamForUri(uri: Uri) = InputStreamWithSource("$uri", BufferedInputStream(URL("$uri").openStream(), 4096))

--- a/android/src/main/java/org/ligi/passandroid/ui/UnzipPassController.kt
+++ b/android/src/main/java/org/ligi/passandroid/ui/UnzipPassController.kt
@@ -40,10 +40,12 @@ object UnzipPassController : KoinComponent {
 
     fun processInputStream(spec: InputStreamUnzipControllerSpec) {
         try {
-            val tempFile = File.createTempFile("ins", "pass")
-            spec.inputStreamWithSource.inputStream.copyTo(FileOutputStream(tempFile))
-            processFile(FileUnzipControllerSpec(tempFile.absolutePath, spec))
-            tempFile.delete()
+            spec.inputStreamWithSource.inputStream.use {
+                val tempFile = File.createTempFile("ins", "pass")
+                it.copyTo(FileOutputStream(tempFile))
+                processFile(FileUnzipControllerSpec(tempFile.absolutePath, spec))
+                tempFile.delete()
+            }
         } catch (e: Exception) {
             tracker.trackException("problem processing InputStream", e, false)
             spec.failCallback?.fail("problem with temp file: $e")


### PR DESCRIPTION
…s (issue #431)

This seems to be occurring because the InputStreamProvider tries to wrap the InputStream in a .use when constructing a fromURI from a content:// URI.  This seems no-longer to work on androids 10 and 11 at least.  Fix this by simply wrappering an ordinary inputStream (as is done for file:// and https://) and instead doing the correct .use directive at the point of use (so the content:// URI is correctly closed).

# PullRequest

Great that you are thinking about submitting a PullRequest!

Please keep them small if not otherwise possible. Contact me *before* you are creating a big PR to avoid unnecessary work and rebasing of big PRs. Also try to add tests - I am not dogmatic about that but prefer PRs backed by tests. This project has everything setup for Espresso UI and Unit-tests. Also the existing unit and UI-tests muss pass before submitting a PullRequest.

Please base the PullRequests on the branch named dev if one currently exists - otherwise use master
