### PR TITLE
Allow the use to copy any text in a pass

### DIFF
--- a/android/src/main/res/layout/barcode.xml
+++ b/android/src/main/res/layout/barcode.xml
@@ -55,5 +55,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
-            android:paddingBottom="8dp" />
+            android:paddingBottom="8dp"
+            android:textIsSelectable="true" />
 </merge>

--- a/android/src/main/res/layout/pkpass_view_extra_data.xml
+++ b/android/src/main/res/layout/pkpass_view_extra_data.xml
@@ -93,6 +93,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:fontFamily="sans-serif"
+				android:textIsSelectable="true"
                 android:padding="24dp"
                 android:visibility="gone"/>
     </LinearLayout>

--- a/android/src/main/res/layout/vertical_field_item.xml
+++ b/android/src/main/res/layout/vertical_field_item.xml
@@ -12,6 +12,7 @@
         android:layout_height="wrap_content"
         android:gravity="center"
         android:fontFamily="sans-serif-light"
+        android:textIsSelectable="true"
         android:textSize="14sp"
         tools:text="Key"
         android:id="@+id/key" />
@@ -21,6 +22,7 @@
         android:layout_height="wrap_content"
 	android:gravity="center"
         android:fontFamily="sans-serif"
+        android:textIsSelectable="true"
         android:textSize="18sp"
         tools:text="Value"
         android:id="@+id/value" />


### PR DESCRIPTION
The user may need to copy text from the pass for many reasons. For example, to connect to the WiFi from Renfe trains company in Spain they ask you for the train ticket number. Being able to just copy and paste it into the form makes it much easier.
