### PR TITLE
Migrate image picker to new Photo Picker

### DIFF
--- a/android/src/main/java/org/ligi/passandroid/ui/PassEditActivity.kt
+++ b/android/src/main/java/org/ligi/passandroid/ui/PassEditActivity.kt
@@ -33,7 +33,7 @@ class PassEditActivity : AppCompatActivity() {
 
     private lateinit var binding: EditBinding
     private lateinit var currentPass: PassImpl
-    private val imageEditHelper by lazy { ImageEditHelper(this, passStore) }
+    private lateinit var imageEditHelper: ImageEditHelper
 
     internal val passStore: PassStore by inject()
 
@@ -50,7 +50,7 @@ class PassEditActivity : AppCompatActivity() {
                 when (i) {
                     0 -> showCategoryPickDialog(this@PassEditActivity, currentPass, refreshCallback)
                     1 -> showColorPickDialog(this@PassEditActivity, currentPass, refreshCallback)
-                    2 -> pickWithPermissionCheck(ImageEditHelper.REQ_CODE_PICK_ICON)
+                    2 -> imageEditHelper.startPick(ImageEditHelper.REQ_CODE_PICK_ICON)
                 }
             }.show()
         }
@@ -78,21 +78,11 @@ class PassEditActivity : AppCompatActivity() {
                     this@PassEditActivity.currentPass,
                     BarCode(PassBarCodeFormat.QR_CODE, UUID.randomUUID().toString().uppercase(Locale.ROOT)))
         }
-    }
 
-    private fun pickWithPermissionCheck(requestCode: Int) {
-        constructPermissionsRequest(Manifest.permission.READ_EXTERNAL_STORAGE) {
-            imageEditHelper.startPick(requestCode)
-        }.launch()
+        imageEditHelper = ImageEditHelper(this, passStore)
     }
 
     val refreshCallback = { refresh(currentPass) }
-
-
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-        imageEditHelper.onActivityResult(requestCode, resultCode, data)
-    }
 
     private fun refresh(pass: Pass) {
         val passViewHolder = EditViewHolder(binding.passCard)
@@ -118,7 +108,7 @@ class PassEditActivity : AppCompatActivity() {
         addButton.visibility = if (bitmap == null) View.VISIBLE else View.GONE
 
         val listener = View.OnClickListener {
-            pickWithPermissionCheck(requestCode)
+            imageEditHelper.startPick(requestCode)
         }
 
         val logoImage = findViewById<ImageView>(logo_img)


### PR DESCRIPTION
With Android 13 the previous photo picker didn't trigger at all anymore. But we can use the new Photo Picker UI as described in [0] to get a new and better photo picker. Some refactoring is necessary to suport that.

[0] https://android-developers.googleblog.com/2023/04/photo-picker-everywhere.html

Fixes #477

---

**NOTE:** I haven't tested this extensively, just a bit on an Android 13 virtual device in Android Studio but everything seems to work there. Before merging (or basing something on this) please test this also on older devices, I don't know how much is available there of this photo picker. Maybe it needs some runtime if.

It's also been a while since I properly did some development for Android so some code could be a bit weird.

<img src="https://github.com/ligi/PassAndroid/assets/3768500/b72d1cb7-1189-494d-9877-c4c80a0cb2f0" width="300"/>
<img src="https://github.com/ligi/PassAndroid/assets/3768500/5ccacf95-5926-405b-8fcc-a98d81878ad3" width="300"/>
